### PR TITLE
Fix for "no data" Service.get / Service.post

### DIFF
--- a/src/Lungo.Service.js
+++ b/src/Lungo.Service.js
@@ -50,6 +50,7 @@ LUNGO.Service = (function(lng, $, undefined) {
         $.ajax({
             type: type,
             url: url,
+            data: data,
             dataType: 'json',
             success: function(response) {
                 if (lng.Core.toType(callback) === 'function') {


### PR DESCRIPTION
get / post functions from Service wasn't working because ajax function (Zepto) wasn't receiving the param "data"
