### PR TITLE
Lungo.View.Template.Bindings

### DIFF
--- a/release/lungo-1.0.1.js
+++ b/release/lungo-1.0.1.js
@@ -833,12 +833,13 @@ LUNGO.View.Template.Binding = (function(lng, undefined) {
     };
 
     var _bindProperties = function(element, template) {
+		var regex;
         for (var property in element) {
             if (lng.Core.isOwnProperty(element, property)) {
-                template = template.replace(BINDING_START + property + BINDING_END, element[property]);
+				regex = new RegExp(BINDING_START + property + BINDING_END, "g");
+				template = template.replace(regex,element[property]);
             }
         }
-
         return _removeNoBindedProperties(template);
     };
 

--- a/src/view/Lungo.View.Template.Binding.js
+++ b/src/view/Lungo.View.Template.Binding.js
@@ -66,12 +66,13 @@ LUNGO.View.Template.Binding = (function(lng, undefined) {
     };
 
     var _bindProperties = function(element, template) {
+		var regex;
         for (var property in element) {
             if (lng.Core.isOwnProperty(element, property)) {
-                template = template.replace(BINDING_START + property + BINDING_END, element[property]);
+				regex = new RegExp(BINDING_START + property + BINDING_END, "g");
+				template = template.replace(regex,element[property]);
             }
         }
-
         return _removeNoBindedProperties(template);
     };
 


### PR DESCRIPTION
The replace in the current _bindProperties will only change one occurrence of a reference. Change made replaces all occurrences.

Eg.  "lng.View.Template.create('div','&lt;li  id="{{id}}"&gt;&lt;strong&gt;@{{name}}&lt;/strong&gt;@{{name}}&lt;/li&gt;')
 In the current version {{name}} would only be changed once."

Haven't used dataAttribute function in the same file but this might also need regExp replace?
