### PR TITLE
Issues Addressed.

### DIFF
--- a/src/Lungo.Events.js
+++ b/src/Lungo.Events.js
@@ -18,7 +18,12 @@ LUNGO.Events = (function(lng, undefined) {
             TOUCH_END: 'touchend',
             TAP: 'tap',
             DOUBLE_TAP: 'doubletap',
-            ORIENTATION_CHANGE: 'orientationchange'
+            ORIENTATION_CHANGE: 'orientationchange',
+			SWIPE:'swipe',
+			SWIPE_LEFT:'swipeLeft',
+			SWIPE_RIGHT:'swipeRight',
+			SWIPE_UP: 'swipeUp',
+			SWIPE_DOWN:'swipeDown'			
         },
         desktop: {
             TOUCH_START: 'click',
@@ -30,9 +35,6 @@ LUNGO.Events = (function(lng, undefined) {
         }
     };
 
-    var current_environment = lng.Environment.current();
-    var current_events = EVENTS[current_environment];
-
     /**
      * Returns the touch event based on an enumeration of LungoJS
      * and the current environment
@@ -43,6 +45,8 @@ LUNGO.Events = (function(lng, undefined) {
      * @return {string} Touch event based on the current environment
      */
     var get = function(eventName) {
+		var current_environment = lng.Environment.current();
+		var current_events = EVENTS[current_environment];
         return current_events[eventName];
     };
 

--- a/src/dom/Lungo.Dom.Event.js
+++ b/src/dom/Lungo.Dom.Event.js
@@ -66,7 +66,7 @@ LUNGO.Dom.Event = (function(lng, undefined) {
     };
 
     /**
-     * Add an event listener without event delegation
+     * Add an event listener with event delegation if enviornment allows event.
      *
      * @method delegate
      *
@@ -76,7 +76,7 @@ LUNGO.Dom.Event = (function(lng, undefined) {
      * @param  {Function} Callback function after the request
      */
     var delegate = function(selector, children_selector, event_name, callback) {
-        if (_isNotSpecialEvent(selector, event_name, callback)) {
+      	if (typeof lng.Events.get(event_name) !== 'undefined') {
             lng.Dom.query(selector).delegate(children_selector, lng.Events.get(event_name), callback);
         }
     };
@@ -123,7 +123,7 @@ LUNGO.Dom.Event = (function(lng, undefined) {
         lng.Dom.query(selector)[special_event](callback);
         */
 
-        switch(event_name) {
+       /* switch(event_name) {
             case 'SWIPE':
                 lng.Dom.query(selector).swipe(callback);
                 break;
@@ -148,7 +148,16 @@ LUNGO.Dom.Event = (function(lng, undefined) {
                 break;
             default:
                 is_special_event = true;
-        }
+        }*/
+		if(event_name === 'DOUBLE_TAP'){
+			if (lng.Environment.isDesktop()) {
+				lng.Dom.query(selector).live(lng.Events.get(event_name), callback);
+            } else {
+                lng.Dom.query(selector).doubleTap(callback);
+            }
+		} else{
+            is_special_event = true;
+		}
 
         return is_special_event;
     };

--- a/src/view/Lungo.View.Template.Binding.js
+++ b/src/view/Lungo.View.Template.Binding.js
@@ -36,6 +36,10 @@ LUNGO.View.Template.Binding = (function(lng, undefined) {
         }
     };
 
+	var forcerender = function(container_id, markup) {
+		 _render(container_id, markup);
+	}
+
     var dataAttribute = function(element, attribute) {
         var data = element.data(attribute.tag);
 
@@ -87,6 +91,7 @@ LUNGO.View.Template.Binding = (function(lng, undefined) {
 
     return {
         create: create,
+		forcerender: forcerender,
         dataAttribute: dataAttribute
     };
 

--- a/src/view/Lungo.View.Template.List.js
+++ b/src/view/Lungo.View.Template.List.js
@@ -15,12 +15,13 @@ LUNGO.View.Template.List = (function(lng, undefined) {
 
     /**
      * Create a list based DataBind with a configuration object for an element <article>
+	 * if the config has a 'norecords' property it will display the norecords markup rather than nothing.
      *
      * @method create
      *
      * @param {object} Id of the container showing the result of databinding
      */
-    var create = function(config) {
+     var create = function(config) {
         _config = config;
         _config.container_id += '_list';
 
@@ -29,8 +30,8 @@ LUNGO.View.Template.List = (function(lng, undefined) {
             // @ToDo >> _group();
             _render();
             _createScroll();
-        }
-    };
+        }     
+	};
 
     var _validateConfig = function() {
         var checked = false;
@@ -44,10 +45,13 @@ LUNGO.View.Template.List = (function(lng, undefined) {
             if (template_exists && _config.data.length) {
                 checked = true;
             }
+			else if(template_exists && _config.hasOwnProperty('norecords')){
+				lng.View.Template.Binding.forcerender(_config.container_id,_config.norecords)
+			}
         }
 
         return checked;
-    };
+};
 
     var _order = function() {
         var order_field = _config.order_field;


### PR DESCRIPTION
Hi,

Hopefully this is clearer/cleaner.

This pull request looks at:

1) Issue where lng.Events.get not returning correct environment.

2). Added swipe events to Events.mobile (Checked with @thomasfuchs they are supported via delegates in Zepto. Also added check environment before allowing binding or attaching event listeners.

3) Suggestion: See what you think about adding a 'norecords' property to lng.View.Template.List.create to optionally display defined markup when the data property has a length of 0.
example:
var config = {
    container_id: 'list_sample',
    template_id: 'pending-tmp',
    data: [...],
    norecords: &lt;li&gt; no records to display &lt;/li&gt; //optional param
};
