### PR TITLE
Correct the asside's toggle behovior

### DIFF
--- a/src/view/Lungo.View.Aside.js
+++ b/src/view/Lungo.View.Aside.js
@@ -19,13 +19,15 @@ LUNGO.View.Aside = (function(lng, undefined) {
     };
 
     var _show = function(section_id) {
-        lng.Dom.query(section_id + ' aside').addClass('show');
+        lng.Dom.query(section_id + ' aside').toggleClass('show');
 
         var articles = lng.Dom.query(section_id + ' article');
         articles.toggleClass('aside');
     };
 
     var _hide = function(section_id) {
+        lng.Dom.query(section_id + ' aside').toggleClass('show');
+        
         var articles = lng.Dom.query(section_id + ' article');
         articles.toggleClass('aside');
     };

--- a/src/view/Lungo.View.Aside.js
+++ b/src/view/Lungo.View.Aside.js
@@ -10,33 +10,12 @@
 
 LUNGO.View.Aside = (function(lng, undefined) {
 
-    var toggle = function(section_id) {
-        if (_isVisible(section_id)) {
-            _hide(section_id);
-        } else {
-            _show(section_id);
-        }
-    };
-
-    var _show = function(section_id) {
-        lng.Dom.query(section_id + ' aside').toggleClass('show');
-
-        var articles = lng.Dom.query(section_id + ' article');
-        articles.toggleClass('aside');
-    };
-
-    var _hide = function(section_id) {
+    var toggle = function(section_id) {        
         lng.Dom.query(section_id + ' aside').toggleClass('show');
         
         var articles = lng.Dom.query(section_id + ' article');
         articles.toggleClass('aside');
-    };
-
-    var _isVisible = function(section_id) {
-        var isVisible = lng.Dom.query(section_id + ' aside').hasClass('show');
-
-        return isVisible;
-    };
+    };    
 
     return {
         toggle: toggle


### PR DESCRIPTION
Hi TapQuo team,

the pull-request is a little correction for the LUNDO.View.Aside.toggle() method.

The bug occured if you use an ipad/iphone device and if you call the toggle method during an event capture : 

```
    lng.Dom.Event.live("#article-links li", 'TAP', function(event){
          LUNGO.View.Aside.toggle("#main");
    });
```

where the id #article-links is the aside element of the main section, and it has a few li elements.

this bug does'nt appear on chrome browser or with using the link in header element.

Regards
