### PR TITLE
Setting the size on all images used within a .list makes it really hard ...

### DIFF
--- a/src/stylesheets/less/Lungo.layout.list.less
+++ b/src/stylesheets/less/Lungo.layout.list.less
@@ -21,7 +21,7 @@
 		padding: 8px 6px 8px 8px;
 		list-style-type: none;
 		
-		& .icon, & img {
+		& .icon {
 			float: left;
 			width: 32px;
 			height: 32px;
@@ -31,7 +31,7 @@
 		}
 	}
     
-	& .icon, & img { 
+	& .icon { 
 		display: inline-block; 
 	}
     


### PR DESCRIPTION
...to use images in .list.

I think a more concise solution would be to add .icon class to images, that are used as icons.
