### PR TITLE
I needed the index of the item of the element, to open up the detailview...

### DIFF
--- a/src/view/Lungo.View.Template.Binding.js
+++ b/src/view/Lungo.View.Template.Binding.js
@@ -59,7 +59,7 @@ LUNGO.View.Template.Binding = (function(lng, undefined) {
     var _bindPropertiesInMultiplesElements = function(elements, template) {
         var markup = '';
         for (var i = 0, len = elements.length; i < len; i++) {
-            markup += _bindProperties(elements[i], template);
+            markup += _bindProperties($$.extend(elements[i],{'index':i}), template);
         }
         return markup;
     };


### PR DESCRIPTION
... and still be able to rely on the same data array.
