### PR TITLE
Correcciones de la visibilidad del target de una section (Route.section)

### DIFF
--- a/src/router/Lungo.Router.js
+++ b/src/router/Lungo.Router.js
@@ -29,7 +29,7 @@ LUNGO.Router = (function(lng, undefined) {
 
         if (_existsTarget(target)) {
             lng.dom(current).removeClass(CLASS.HIDE_REVOKE).removeClass(CLASS.SHOW).addClass(CLASS.HIDE);
-            lng.dom(target).removeClass(CLASS.SHOW_REVOKE).addClass(CLASS.SHOW).trigger(TRIGGER.LOAD);
+            lng.dom(target).removeClass(CLASS.SHOW_REVOKE).addClass(CLASS.SHOW).removeClass(CLASS.HIDE).trigger(TRIGGER.LOAD);
 
             lng.Router.History.add(section_id);
         }


### PR DESCRIPTION
Correcciones de la visibilidad del target de una section

Tengo, entre otras dos, sections: 1 - Home y 2 - Registro.

Al iniciar la aplicación se ve la "Home", y al comprobar que no existe un usuario registrado lo redirecciono mediante Route.section a la section "Registro". Una vez cumplimentados los datos redirecciono al usuario a la section "Home". El caso es que la section "Home" no se ve porque se mantiene la class "hide". Con este cambio se quita la class "hide" del elemento target.

Saludos de un seguidor de lungoJS.

Que conste que es mi primer pull request en cualquier respositorio ;)
