### PR TITLE
Solución error al insertar registros en la base de datos

### DIFF
--- a/src/data/Lungo.Data.Sql.js
+++ b/src/data/Lungo.Data.Sql.js
@@ -194,7 +194,7 @@ LUNGO.Data.Sql = (function(lng, undefined) {
                 var value = row[field];
                 fields += (fields) ? ', ' + field : field;
                 if (values) values += ', ';
-                values += (isNaN(value)) ? '"' + value + '"' : value;
+                values += (isNaN(value) || value=='') ? '"' + value + '"' : value;
             }
         }
 


### PR DESCRIPTION
La funcion isNaN()  toma como numerico las cadenas vacias, cuando en la sql debería hacerlo insertarlo como ''
