### PR TITLE
Corrections on Router for sections classes when hiding & showing current & target sections

### DIFF
--- a/src/router/Lungo.Router.js
+++ b/src/router/Lungo.Router.js
@@ -39,7 +39,7 @@ Lungo.Router = (function(lng, undefined) {
                 }
 
                 current.removeClass(CLASS.SHOW).addClass(CLASS.HIDE);
-                target.addClass(CLASS.SHOW);
+                target.removeClass(CLASS.HIDE).addClass(CLASS.SHOW);
                 lng.Element.Cache.section = target;
                 lng.Element.Cache.article = target.find(ELEMENT.ARTICLE + '.' + CLASS.CURRENT);
 


### PR DESCRIPTION
It's the same pull request #94 ( https://github.com/TapQuo/Lungo.js/pull/94 ) but updated to the new 2.0 version of Lungo.js

It's all about removing and adding the same "inverted" SHOW & HIDE classes to both current & target sections, because it ran on visibility problems when i went to the same target from current at second time. At second time the target had the HIDE class and it wasn't shown.

Thank's a lot Javi.
