### PR TITLE
Fixed W3C validation for http-equiv attribute

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -10,7 +10,9 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="format-detection" content="telephone=no">
-    <meta http-equiv="cleartype" content="on">
+	<!--[if IEMobile]>
+		<meta http-equiv="cleartype" content="on">
+	<![endif]-->
 
     <!-- iPhone -->
     <link href="http://lungo.tapquo.com/resources/icon-57.png" sizes="57x57" rel="apple-touch-icon">


### PR DESCRIPTION
When I try to make W3C validation, it retrieves me the next:

```
 Bad value ClearType for attribute http-equiv on element meta.
```

So I omit this line when isn't IEMobile browser.
