### PR TITLE
Fix for rewinding history too far.

### DIFF
--- a/src/router/Lungo.Router.History.js
+++ b/src/router/Lungo.Router.History.js
@@ -42,7 +42,9 @@ Lungo.Router.History = (function(undefined) {
       * @method removeLast
       */
      var removeLast = function() {
-         _history.length -= 1;
+         if (_history.length > 0) {
+          _history.length -= 1;
+        }
      };
 
     return {

--- a/src/router/Lungo.Router.History.js
+++ b/src/router/Lungo.Router.History.js
@@ -42,9 +42,7 @@ Lungo.Router.History = (function(undefined) {
       * @method removeLast
       */
      var removeLast = function() {
-         if (_history.length > 0) {
-          _history.length -= 1;
-        }
+          _history.pop();
      };
 
     return {


### PR DESCRIPTION
Make sure that history.removeLast can't go back too far.  This is a painless error check, and has actually happened to me in the wild by accident.
