### PR TITLE
Fixed css stylus source so they get compiled correctly.

### DIFF
--- a/src/stylesheets/lungo.base.styl
+++ b/src/stylesheets/lungo.base.styl
@@ -86,9 +86,14 @@ article, aside, details, figcaption, figure, footer, header, hgroup, nav, sectio
   display: block
 
 
-audio, canvas, video display: inline-block *display: inline *zoom: 1
-audio:not([controls]) display: none
-[hidden]  display: none
+audio, canvas, video
+  display: inline-block
+  *display: inline
+  *zoom: 1
+audio:not([controls])
+  display: none
+[hidden]
+  display: none
 
 html
   height: 100%


### PR DESCRIPTION
Add newlines so the css properties are not taken as if they were selectors.

Without those linebreaks, the generated css file is invalid. Including `lungo.css` on a rails application and trying to compile it, fails due to malformed css. 

```
Invalid CSS after "...,video display:": expected pseudoclass or pseudoelement, was " inline-block *..."
  (in lungo.css)
```

Adding line breaks to separate selectors from their css properties on the stylus source has fixed this.
