### PR TITLE
add a new method in carousel called 'goto'

### DIFF
--- a/src/element/Lungo.Element.Carousel.coffee
+++ b/src/element/Lungo.Element.Carousel.coffee
@@ -34,6 +34,10 @@ Lungo.Element.Carousel = (element, callback) ->
     else
       _slide 0, _instance.speed
 
+  goto = (index, delay) ->
+    if (index > 0) and (index < _instance.slides_length)
+      _slide index, _instance.speed
+
   position = ->
     _instance.index
 
@@ -108,8 +112,9 @@ Lungo.Element.Carousel = (element, callback) ->
 
   _setup()
   _handleGestures()
-
+  
   prev: prev
   next: next
+  goto: goto
   position: position
   refresh: refresh


### PR DESCRIPTION
'goto' is a simple method to go to the slide that you want.

goto(4)....slide in the position 4

this is useful if we have a menu with the list of slides.
