### PR TITLE
Fixed Lungo css and js pash in example 

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -46,7 +46,7 @@
 
     <!-- Main Stylesheet -->
     <link rel="stylesheet" href="components/lungo.brownie/lungo.css">
-    <link rel="stylesheet" href="components/lungo.brownie/lungo.theme.css" id="theme-stylesheet">
+    <link rel="stylesheet" href="components/lungo.brownie/theme.lungo.css" id="theme-stylesheet">
     <link rel="stylesheet" href="components/lungo.icon/lungo.icon.css">
     <!-- App Stylesheet -->
     <link rel="stylesheet" href="static/stylesheets/app.css">
@@ -120,7 +120,7 @@
 
     <!-- Lungo dependencies -->
     <script src="components/quojs/quo.js"></script>
-    <script src="components/lungo.brownie/lungo.debug.js"></script>
+    <script src="components/lungo.brownie/lungo.js"></script>
     <!-- LungoJS - Sandbox App -->
     <script>
         Lungo.init({

--- a/example/navigation.html
+++ b/example/navigation.html
@@ -14,7 +14,7 @@
 
     <!-- Main Stylesheet -->
     <link rel="stylesheet" href="components/lungo.brownie/lungo.css">
-    <link rel="stylesheet" href="components/lungo.brownie/lungo.theme.css">
+    <link rel="stylesheet" href="components/lungo.brownie/theme.lungo.css">
     <link rel="stylesheet" href="components/lungo.icon/lungo.icon.css">
 </head>
 
@@ -70,7 +70,7 @@
 
     <!-- Lungo dependencies -->
     <script src="components/quojs/quo.js"></script>
-    <script src="components/lungo.brownie/lungo.debug.js"></script>
+    <script src="components/lungo.brownie/lungo.js"></script>
     <!-- LungoJS - Sandbox App -->
     <script>
         Lungo.init({


### PR DESCRIPTION
Fixed the path for theme.lungo (previos lungo.theme) css and the lungo.debug (doesn't exist in the lungo.brownie package).
