### PR TITLE
Fixed Submodule Urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,8 +35,8 @@
     path = packages/lungo.icon
     url = https://github.com/tapquo/lungo.icon.git
 [submodule "lungo.firefoxos"]
-	path = packages/lungo.firefoxos
-	url = https://github.com/tapquo/lungo.firefoxos.git
+    path = packages/lungo.firefoxos
+    url = https://github.com/tapquo/lungo.firefoxos.git
 [submodule "packages/lungo.calendar"]
-	path = packages/lungo.calendar
-	url = https://github.com/tapquo/lungo.firefoxos.git
+    path = packages/lungo.calendar
+    url = https://github.com/tapquo/lungo.calendar.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "packages/lungo"]
     path = packages/lungo
-    url = https://github.com/TapQuo/package-lungo
+    url = https://github.com/tapquo/package-lungo
 [submodule "packages/lungo.theme"]
     path = packages/lungo.theme
-    url = https://github.com/TapQuo/package-lungo.theme
+    url = https://github.com/tapquo/package-lungo.theme
 [submodule "src/stylesheets/CSSmethods"]
     path = src/stylesheets/CSSmethods
     url = https://github.com/soyjavi/CSSmethods
@@ -12,31 +12,31 @@
     url = https://github.com/soyjavi/package-quojs
 [submodule "packages/lungo.thirdparties"]
     path = packages/lungo.thirdparties
-    url = https://github.com/TapQuo/lungo.thirdparties.git
+    url = https://github.com/tapquo/lungo.thirdparties.git
 [submodule "packages/lungo.gmap"]
     path = packages/lungo.gmap
-    url = https://github.com/TapQuo/lungo.gmap.git
+    url = https://github.com/tapquo/lungo.gmap.git
 [submodule "packages/lungo.qr"]
     path = packages/lungo.qr
-    url = https://github.com/TapQuo/lungo.qr.git
+    url = https://github.com/tapquo/lungo.qr.git
 [submodule "packages/lungo.language"]
     path = packages/lungo.language
-    url = https://github.com/TapQuo/lungo.language.git
+    url = https://github.com/tapquo/lungo.language.git
 [submodule "packages/lungo.mock"]
     path = packages/lungo.mock
-    url = https://github.com/TapQuo/lungo.mock.git
+    url = https://github.com/tapquo/lungo.mock.git
 [submodule "packages/lungo.terminal"]
     path = packages/lungo.terminal
-    url = https://github.com/TapQuo/lungo.terminal.git
+    url = https://github.com/tapquo/lungo.terminal.git
 [submodule "example/components/lungo.brownie"]
     path = example/components/lungo.brownie
     url = https://github.com/soyjavi/lungo.brownie.git
 [submodule "packages/lungo.icon"]
     path = packages/lungo.icon
-    url = https://github.com/TapQuo/lungo.icon.git
+    url = https://github.com/tapquo/lungo.icon.git
 [submodule "lungo.firefoxos"]
 	path = packages/lungo.firefoxos
-	url = https://github.com/TapQuo/lungo.firefoxos.git
+	url = https://github.com/tapquo/lungo.firefoxos.git
 [submodule "packages/lungo.calendar"]
 	path = packages/lungo.calendar
-	url = https://github.com/TapQuo/lungo.firefoxos.git
+	url = https://github.com/tapquo/lungo.firefoxos.git


### PR DESCRIPTION
There were various submodule urls that were incorrect, which caused various issues when cloning the repo or updating submodules. I've fixed all urls, which resolves the aforementioned issues. It also resolves your most current issue ... https://github.com/tapquo/Lungo.js/issues/201
