### PR TITLE
Adding a package.json to lower the barrier to start contributing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "Lungo.js",
+  "version": "2.1.0511",
+  "description": "Lungo - HTML5 Cross-Device Framework",
+  "main": "GruntFile.js",
+  "directories": {
+    "example": "example"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/tapquo/Lungo.js.git"
+  },
+  "keywords": [
+    "Lungo.js",
+    "mobile"
+  ],
+  "author": "Javier Jimenez Villar <javi@tapquo.com>",
+  "license": "LUNGOJS License",
+  "readmeFilename": "README.md",
+  "dependencies": {
+    "grunt": "",
+    "grunt-contrib-coffee": "",
+    "grunt-contrib-stylus": "",
+    "grunt-contrib-concat": "",
+    "grunt-contrib-uglify": "",
+    "grunt-contrib-copy": "",
+    "grunt-contrib-watch": ""    
+  }
+}


### PR DESCRIPTION
When I started playing around with Lungo.js directly, it kinda put me off that all the grunt-plugins etc. needed to be installed manually, as there wasn't a package.json.

So, well, I added one. Now getting ready to hack&build is (more or less) just

```
$ npm install
```

If you have some adjustments to suggest, I'd be more than happy to incorporate those.
