### PR TITLE
a bug of Notification

### DIFF
--- a/src/modules/Lungo.Notification.coffee
+++ b/src/modules/Lungo.Notification.coffee
@@ -57,10 +57,15 @@ Lungo.Notification = do(lng = Lungo) ->
   @method   hide
   ###
   hide = ->
-    _window.removeClass("show")
+    wait = 0
+    unless _window.hasClass("show")
+      wait = (TRANSITION.DURATION / 2)
     setTimeout (->
-      _el.removeClass("show").removeClass("html").removeClass("confirm").removeClass("notify").removeClass "growl"
-    ), (TRANSITION.DURATION / 2)
+      _window.removeClass("show")
+      setTimeout (->
+        _el.removeClass("show").removeClass("html").removeClass("confirm").removeClass("notify").removeClass "growl"
+      ), (TRANSITION.DURATION / 2)
+    ),  wait
 
 
   ###


### PR DESCRIPTION
in some cases, i found that when i trigger the 'show' and the 'hide' method of lng.Notification in a short time less then 200ms, the variable '_window' in lng.Notification would still be 'show', so the 'show' method would not work anymore.

i think these codes could fix the bug, anyway i dont code coffee very usual, hope it will be helpful:)
