### PR TITLE
Added a meta value for 'mobile-web-app-capable' to support Chrome on Android

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="format-detection" content="telephone=no">
     <meta http-equiv="cleartype" content="on">
 

--- a/example/others/components.html
+++ b/example/others/components.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="format-detection" content="telephone=no">
     <meta http-equiv="cleartype" content="on">
 

--- a/example/others/tablet1.html
+++ b/example/others/tablet1.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="mobile-web-app-capable" content="yes">    
     <meta name="format-detection" content="telephone=no">
     <meta http-equiv="cleartype" content="on">
 

--- a/example/others/tablet2.html
+++ b/example/others/tablet2.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="format-detection" content="telephone=no">
     <meta http-equiv="cleartype" content="on">
 

--- a/example/others/tablet3.html
+++ b/example/others/tablet3.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="format-detection" content="telephone=no">
     <meta http-equiv="cleartype" content="on">
 

--- a/example/others/tablet4.html
+++ b/example/others/tablet4.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="format-detection" content="telephone=no">
     <meta http-equiv="cleartype" content="on">
 


### PR DESCRIPTION
According to the [Add to Homescreen](https://developers.google.com/chrome/mobile/docs/installtohomescreen) feature of Chrome Android M31, in order to support homescreen apps:

> Chrome will look for the following meta tag in the <head> element of the web-page:
> 
> <meta name="mobile-web-app-capable" content="yes">

Additionally,

> Chrome will also allow Web Apps to launch in "App mode" if they embed a meta tag using the "apple-mobile-web-app-capable" name. Chrome will stop supporting this usage in an upcoming release.

This PR is an attempt to future proof the repo as well as support a feature that will soon become more common on Android devices.
